### PR TITLE
updated for accessibility - team page

### DIFF
--- a/style.css
+++ b/style.css
@@ -124,7 +124,7 @@ form {
 
 p {
   color: white;
-  text-align: justify;
+  text-align: left;
   
 }
 
@@ -236,24 +236,22 @@ button {
   font-family: "Rowdies", sans-serif;
 }
 
-button.super-hero-btn {
+.super-hero-link {
   text-align: left;
   color: #fff;
-  border: none;
   cursor: pointer;
   margin-left: 0px;
-  background-color: transparent;
-  box-shadow: none;
   padding-left: 10px;
-  height: fit-content;
-  
+  padding-bottom: 20px;
+  padding-top: 15px;
+  font-size: 18px;
 }
 
 
 
 a {
   color: #fff;
-  text-decoration: none;
+  text-decoration: underline;
   margin-right: 1px ;
   transition: margin-right 0.3s;
 }
@@ -295,7 +293,7 @@ i {
 
 aside {
   padding: 10px;
-  text-align: justify;
+  text-align: left;
 }
 
 img {

--- a/team.html
+++ b/team.html
@@ -16,9 +16,9 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
     />
     <link
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
-  />
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
+    />
     <link rel="icon" type="image/x-icon" href="Images/logo.jpeg" />
     <title>Team</title>
   </head>
@@ -57,10 +57,10 @@
             For a small additional fee, Batman comes with a top-tier team on his
             side, including his butler Alfred and sidekick Robin.
           </aside>
-          <button type="button" class="super-hero-btn">
+          <div class="super-hero-link">
             <a href="https://www.dc.com/characters/batman">More info</a>
             <i class="fa-sharp fa-solid fa-arrow-right"></i>
-          </button>
+          </div>
         </article>
         <article class="bioBox">
           <h2>Spiderman</h2>
@@ -81,12 +81,12 @@
             skilled photographer and writer to meet both your crime-fighting and
             marketing needs.
           </aside>
-          <button type="button" class="super-hero-btn">
+          <div class="super-hero-link">
             <a href="https://www.marvel.com/characters/spider-man-peter-parker"
               >More info</a
             >
             <i class="fa-sharp fa-solid fa-arrow-right"></i>
-          </button>
+          </div>
         </article>
       </section>
 
@@ -110,13 +110,13 @@
             ability and strength to transport equipment mean that all the work
             she takes on can be easily kept on budget.
           </aside>
-          <button type="button" class="super-hero-btn">
+          <div class="super-hero-link">
             <a href="https://www.dc.com/characters/wonder-woman">More info</a>
             <i class="fa-sharp fa-solid fa-arrow-right"></i>
-          </button>
+          </div>
         </article>
         <article class="bioBox">
-          <h2>Ironman</h2>
+          <h2>Iron Man</h2>
           <div class="super-hero-image">
             <img
               class="bioImage"
@@ -135,12 +135,12 @@
             needed to make himself stronger, but now he’s ready to make your
             organisation stronger as well.
           </aside>
-          <button type="button" class="super-hero-btn">
+          <div class="super-hero-link">
             <a href="https://www.marvel.com/characters/iron-man-tony-stark"
               >More info</a
             >
             <i class="fa-sharp fa-solid fa-arrow-right"></i>
-          </button>
+          </div>
         </article>
       </section>
     </main>


### PR DESCRIPTION
I've done the following to make the page more accessible:

1. moved the alignment from justify content to left-aligned 
2. changed the "more info" buttons to no longer be buttons and just be links – this was causing confusion for tabbed browsing, and they didn't meet the accessible definition of 'buttons' because they went to another page. I restyled the links so they look much the same as before
3. underlined the links to make it clearer that they are links

This page gets 100% in Lighthouse, and I've successfully tested it with tabbed browsing, a screen reader, and enlarging the text. It also meets almost all of the recommendations here: https://www.a11yproject.com/checklist/

The only thing to possible add is a skip-link so the menu doesn't get read on every page, but as the menu is only three items this seems low priority. 